### PR TITLE
Update a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,9 +160,9 @@
       }
     },
     "@types/express": {
-      "version": "4.17.8",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
-      "integrity": "sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==",
+      "version": "4.17.9",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.9.tgz",
+      "integrity": "sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -178,9 +178,9 @@
       "dev": true
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
-      "integrity": "sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
+      "integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -219,9 +219,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
-      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
+      "version": "14.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
       "dev": true
     },
     "@types/qs": {
@@ -237,13 +237,13 @@
       "dev": true
     },
     "@types/serve-static": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
-      "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.7.tgz",
+      "integrity": "sha512-3diZWucbR+xTmbDlU+FRRxBf+31OhFew7cJXML/zh9NmvSPTNoFecAwHB66BUqFgENJtqMiyl7JAwUE/siqdLw==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "@types/sizzle": {
@@ -351,6 +351,13 @@
         "sweetalert2": "^9.10.8",
         "tempusdominus-bootstrap-4": "^5.1.2",
         "toastr": "^2.1.4"
+      },
+      "dependencies": {
+        "bootstrap-switch": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/bootstrap-switch/-/bootstrap-switch-3.3.4.tgz",
+          "integrity": "sha1-cOCusqh3wNx2aZHeEI4hcPwpov8="
+        }
       }
     },
     "amdefine": {
@@ -751,11 +758,6 @@
       "version": "10.6.2",
       "resolved": "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-10.6.2.tgz",
       "integrity": "sha512-8JTPZB9QVOdrGzYF3YgC3YW6ssfPeBvBwZnXffiZ7YH/zz1D0EKlZvmQsm/w3N0XjVNYQEoQ0ax+jHrErV4K1Q=="
-    },
-    "bootstrap-switch": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/bootstrap-switch/-/bootstrap-switch-3.3.4.tgz",
-      "integrity": "sha1-cOCusqh3wNx2aZHeEI4hcPwpov8="
     },
     "bootstrap4-duallistbox": {
       "version": "4.0.2",
@@ -5128,6 +5130,26 @@
         "moment": "^2.22.2",
         "moment-timezone": "^0.5.11",
         "popper.js": "^1.14.3"
+      }
+    },
+    "tempusdominus-core": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/tempusdominus-core/-/tempusdominus-core-5.0.3.tgz",
+      "integrity": "sha512-52lClmU33gb6J6I/S9uGDrgQwccq3Yw9SlZerTgGLOzOB3Sc9pgIVBirfPMsMcx8nPsg6mA5ItFAH/5BZiQThg==",
+      "requires": {
+        "jquery": "^3.0",
+        "moment": "^2.22.2",
+        "moment-timezone": "^0.4.0"
+      },
+      "dependencies": {
+        "moment-timezone": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
+          "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
+          "requires": {
+            "moment": ">= 2.6.0"
+          }
+        }
       }
     },
     "term-size": {

--- a/package.json
+++ b/package.json
@@ -30,15 +30,16 @@
     "jsgrid": "^1.5.3",
     "multer": "^1.4.2",
     "popper.js": "^1.16.1",
+    "tempusdominus-core": "^5.0.3",
     "winston": "^3.3.3"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.2",
-    "@types/express": "^4.17.8",
+    "@types/express": "^4.17.9",
     "@types/express-handlebars": "^3.1.0",
     "@types/jquery": "^3.5.4",
     "@types/multer": "^1.4.4",
-    "@types/node": "^14.14.6",
+    "@types/node": "^14.14.7",
     "grunt": "^1.3.0",
     "grunt-concurrent": "^3.0.0",
     "grunt-contrib-watch": "^1.1.0",


### PR DESCRIPTION
Updated a dependency

When I run npm i I still the following warnings :
```
npm WARN bootstrap-switch@3.3.4 requires a peer of bootstrap@^3.1.1 but none is installed. You must install peer dependencies yourself.
npm WARN grunt-tslint@5.0.2 requires a peer of tslint@^5.0.0 || ^5.0.0-dev || ^5.1.0-dev || ^5.2.0-dev || ^5.3.0-dev but none is installed. You must install peer dependencies yourself.
```
1) Bootstrap-switch requires bootstrap 3 as a dependency, thus the warning. However on their repo (https://github.com/Bttstrp/bootstrap-switch) it's written that it's also compatible with bootstrap 4 so I'll ignore this warning for now until I notice a bug I think.
2) Need to update tslint to eslint, will do it later in another PR as there are quite a few changes. I've read a bit the documentation, doesn't seem too hard but might take some time to make sure everything works correctly.